### PR TITLE
Fix of "Talk page not found" error due to Wikipedia API change

### DIFF
--- a/scripts/01_extract_discussions.py
+++ b/scripts/01_extract_discussions.py
@@ -31,7 +31,7 @@ archive_MiszaBot_template_re = re.compile(r'\{\{User:MiszaBot/config.*?counter\s
 archive_box_template_re = re.compile(r'\{\{archive.*?\|.*?(\[\[/.*?)\}\}', re.DOTALL) #for xml
 link_re = re.compile(r'\[\[([^|]*?)(?:\|.*?)*?\]\]')
 
-xml_metadata_re = re.compile('<page pageid="(.+?)" ns="1" title="(.+?)">', re.DOTALL)
+xml_metadata_re = re.compile('<page .+? pageid="(.+?)" ns="1" title="(.+?)">', re.DOTALL)
 xml_text_re = re.compile('<rev .*? xml:space="preserve">(.*)</rev>', re.DOTALL)
 redirectP = re.compile(r'#REDIRECT \[\[(.*)\]\]')
 


### PR DESCRIPTION
New attribute '_idx' was added in the API response which broke the regular expression on line 34. This has been fixed. See issue #1 